### PR TITLE
Have CI check Markdown links on any branch

### DIFF
--- a/.github/workflows/markdown-links.yml
+++ b/.github/workflows/markdown-links.yml
@@ -2,9 +2,6 @@ name: Check Markdown links
 
 on:
   push:
-    branches:
-      - master
-      - gh-pages
   pull_request:
   schedule:
     - cron: '15 0,12 * * *'


### PR DESCRIPTION
Not just master and gh-pages.